### PR TITLE
修复wz-s主动模式下因数据干扰导致的传感器数值不稳定的问题

### DIFF
--- a/components/ws_z/ws_z.cpp
+++ b/components/ws_z/ws_z.cpp
@@ -80,34 +80,40 @@ void DARTWSZComponent::loop() {
       if (!this->read_byte(&c)) {
         return;
       }
-    if (c != 0xFF) {
-      continue;
-    }
-    // 找到帧头后，读取后续的8个字节数据
-    uint8_t data[8];
-    if (!this->read_array(data, 8)) {
-      return;
-    }
-    // 校验和检查
-    uint8_t sum = 0;
-    for (int i = 0; i < 8; i++) {
-      sum += data[i];
-    }
-    if (sum != 0) {
-      // 校验失败的数据包直接丢弃
-      ESP_LOGW(TAG, "Checksum failed! Discarding packet. Sum: 0x%02X", sum);
-      continue;
-    }
-    // 检查 甲醛ID(0x17) 和 Ppb单位(0x04)
-    if (data[0] == 0x17 && data[1] == 0x04) {
-      // 浓度值位置在第4和第5字节 (数组索引为 data[3] 和 data[4])
-      uint32_t val = (uint32_t(data[3]) << 8) | uint32_t(data[4]);
-      if (this->formaldehyde_ppb_sensor_ != nullptr) {
-        this->formaldehyde_ppb_sensor_->publish_state(val);
+      // 寻找 0xFF 帧头
+      if (c != 0xFF) {
+        continue;
       }
-    } else {
-      // 如果收到其他ID或单位的数据，也记录下来
-      ESP_LOGW(TAG, "Ignoring frame with unknown ID/Unit. ID: 0x%02X, Unit: 0x02X", data[0], data[1]);
+
+      // 找到帧头后，读取后续的8个字节数据
+      uint8_t data[8];
+      if (!this->read_array(data, 8)) {
+        return;
+      }
+
+      // 校验和检查
+      uint8_t sum = 0;
+      for (int i = 0; i < 8; i++) {
+        sum += data[i];
+      }
+
+      if (sum != 0) {
+        // 校验失败的数据包直接丢弃
+        ESP_LOGW(TAG, "Checksum failed! Discarding packet. Sum: 0x%02X", sum);
+        continue;
+      }
+
+      // 检查 甲醛ID(0x17) 和 Ppb单位(0x04)
+      if (data[0] == 0x17 && data[1] == 0x04) {
+        // 浓度值位置在第4和第5字节 (数组索引为 data[3] 和 data[4])
+        uint32_t val = (uint32_t(data[3]) << 8) | uint32_t(data[4]);
+        if (this->formaldehyde_ppb_sensor_ != nullptr) {
+          this->formaldehyde_ppb_sensor_->publish_state(val);
+        }
+      } else {
+        // 如果收到其他ID或单位的数据，也记录下来
+        ESP_LOGW(TAG, "Ignoring frame with unknown ID/Unit. ID: 0x%02X, Unit: 0x02X", data[0], data[1]);
+      }
     }
   }
 }

--- a/components/ws_z/ws_z.cpp
+++ b/components/ws_z/ws_z.cpp
@@ -74,17 +74,40 @@ void DARTWSZComponent::update() {
 }
 
 void DARTWSZComponent::loop() {
-  uint16_t ch20h_ppb = 0;
   if (this->mode_ == DARTWS_MODE_ACTIVE) {
     while (this->available()) {
-      this->buffer.push_back((uint8_t)this->read());
-    }
-    if(this->buffer.size() >= DART_RESPONSE_LENGTH) {
-      ch20h_ppb = uint16_t(this->buffer[4]) * 256 + this->buffer[5];
-      if(this->formaldehyde_ppb_sensor_ != nullptr ) {
-        this->formaldehyde_ppb_sensor_->publish_state(ch20h_ppb);
+      uint8_t c;
+      if (!this->read_byte(&c)) {
+        return;
       }
-      this->buffer.erase(this->buffer.begin(), this->buffer.begin() + DART_RESPONSE_LENGTH);
+    if (c != 0xFF) {
+      continue;
+    }
+    // 找到帧头后，读取后续的8个字节数据
+    uint8_t data[8];
+    if (!this->read_array(data, 8)) {
+      return;
+    }
+    // 校验和检查
+    uint8_t sum = 0;
+    for (int i = 0; i < 8; i++) {
+      sum += data[i];
+    }
+    if (sum != 0) {
+      // 校验失败的数据包直接丢弃
+      ESP_LOGW(TAG, "Checksum failed! Discarding packet. Sum: 0x%02X", sum);
+      continue;
+    }
+    // 检查 甲醛ID(0x17) 和 Ppb单位(0x04)
+    if (data[0] == 0x17 && data[1] == 0x04) {
+      // 浓度值位置在第4和第5字节 (数组索引为 data[3] 和 data[4])
+      uint32_t val = (uint32_t(data[3]) << 8) | uint32_t(data[4]);
+      if (this->formaldehyde_ppb_sensor_ != nullptr) {
+        this->formaldehyde_ppb_sensor_->publish_state(val);
+      }
+    } else {
+      // 如果收到其他ID或单位的数据，也记录下来
+      ESP_LOGW(TAG, "Ignoring frame with unknown ID/Unit. ID: 0x%02X, Unit: 0x02X", data[0], data[1]);
     }
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Implement robust packet parsing in active mode by scanning for frame header, verifying checksum, filtering by sensor ID and unit, and discarding invalid frames with warning logs to stabilize formaldehyde sensor readings

Bug Fixes:
- Fix unstable formaldehyde sensor readings in active mode caused by data interference

Enhancements:
- Replace naive buffer-based parsing with explicit frame header detection, checksum validation, and ID/unit filtering
- Add warning logs for checksum failures and ignored frames